### PR TITLE
Correction on the COUNS12km testcase scripts

### DIFF
--- a/testcases/conus_12-km/namelist_v4.5.2_conus12km_restart.input
+++ b/testcases/conus_12-km/namelist_v4.5.2_conus12km_restart.input
@@ -52,9 +52,7 @@
  smooth_option                       = 0
  num_metgrid_levels                  = 34,
  num_metgrid_soil_levels             = 4,
- numtiles                            = 4,
- nproc_x                             = 8,
- nproc_y                             = 24, 
+ numtiles                            = 1,
  /
 
  &physics

--- a/testcases/conus_12-km/namelist_v4.5.2_conus12km_restart.input
+++ b/testcases/conus_12-km/namelist_v4.5.2_conus12km_restart.input
@@ -1,6 +1,6 @@
  &time_control
- run_days                            = 5,
- run_hours                           = 0,
+ run_days                            = 0,
+ run_hours                           = 6,
  run_minutes                         = 0,
  run_seconds                         = 0, 
  start_year                          = 2008,
@@ -52,7 +52,7 @@
  smooth_option                       = 0
  num_metgrid_levels                  = 34,
  num_metgrid_soil_levels             = 4,
- numtiles                            = 1,
+ numtiles                            = 1, !need to change this value = $OMP_NUM_THREADS when using OpenMP
  /
 
  &physics

--- a/testcases/conus_12-km/setup_rundir_WRF.sh
+++ b/testcases/conus_12-km/setup_rundir_WRF.sh
@@ -19,14 +19,10 @@ mkdir -p ${rundir}
 cd ${rundir}
 pwd
 
-#get input files from NERSC's WRFSIG CFS space through Science Gateway service
+#get input files from NERSC's WRFSIG CFS space
 echo "downloading input file archive"
 
-wget https://portal.nersc.gov/cfs/m4232pub/testcase_input/testcase_input_conus12km_v4.5.2.tar.gz
-
-echo "expanding the input file arhive"
-
-tar -zxf testcase_input_conus12km_v4.5.2.tar.gz
+cp -r /global/cfs/cdirs/m4232pub/data/testcase_input/conus12km/v4.5.2/* .
 
 echo "finished copying the input files"
 


### PR DESCRIPTION
Changes to the WRF namelist and three shell scripts were made to avoid MPI errors that Woo-Sun encountered and set run time appropriate for the initial profiling and testing stages of the summer internship.

TYPE: bug fix

DESCRIPTION OF CHANGES:
Problem:
- The namelist variables nproc_x and nproc_y for domain decomposition were set to be optimal for specific MPI ranks  of 192
- The link for the tar archive of the input data does not work anymore
- Simulation time (5 days) is too long for quick testing
- The batch script used the WRF module instead of the model executive compiled by the user/intern student
- Other small improvements in the batch script


Solution:
- the variables nproc_x and nproc_y  were removed from the namelist (namelist_v4.5.2_conus12km_restart.input) so that WRF uses its default way of decomposing the domain for given MPI tasks.
- the variable numtiles is set to 1 as the default of the test case (no OpenMP)
- other small improvements in the sbatch script to make it easier to use different number of MPI tasks and tasks per node, adopted from Woo-Sun's benchmarking script
- directly copy the input files from the WRF-SIG CFS space
- simulation length changed to 6 hours from 5 days

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)
- namelist_v4.5.2_conus12km_restart.input
- setup_rundir_WRF.sh
- sub_wrf_pm_testcase.sh


TESTS CONDUCTED: 
A few test simulations; now, 68 MPI tasks on a single node finish the simulation in a few minutes, writing one output file (3:22 with no compiler optimization (debug = true) and 2:12 with the default optimization O2).

