### PR TITLE
Temporarily remove the gpu-bind flag because of job failures with one…

### DIFF
--- a/testcases/conus_12-km/sub_wrf_pm_testcase.sh
+++ b/testcases/conus_12-km/sub_wrf_pm_testcase.sh
@@ -71,10 +71,11 @@ if [[ $use_gpu -eq 0 ]]; then
   srun -n $n -c $c --cpu-bind=cores /global/common/software/m4232/pm/v4.5.2/wrf.exe
 else
   (( c = (64 / (n / SLURM_JOB_NUM_NODES)) * 2 ))
-  srun -n $n -c $c --cpu-bind=cores --gpus-per-task=1 --gpu-bind=none /global/common/software/m4232/pm/v4.5.2/wrf.exe
+# srun -n $n -c $c --cpu-bind=cores --gpus-per-task=1 --gpu-bind=none /global/common/software/m4232/pm/v4.5.2/wrf.exe
+  srun -n $n -c $c --cpu-bind=cores --gpus-per-task=1                 /global/common/software/m4232/pm/v4.5.2/wrf.exe
 # Profile with Nsight Compute:
 # srun --ntasks-per-node=1 dcgmi profile --pause
-# srun -n $n -c $c --cpu_bind=cores --gpus-per-task=1 --gpu-bind=none ./wrapper-ncu.sh /global/common/software/m4232/pm/v4.5.2/wrf.exe
+# srun -n $n -c $c --cpu-bind=cores --gpus-per-task=1                 ./wrapper-ncu.sh /global/common/software/m4232/pm/v4.5.2/wrf.exe
 # srun --ntasks-per-node=1 dcgmi profile --resume
 fi
 


### PR DESCRIPTION
This is to temporarily remove the `--gpu-bind=none` flag from the srun command because of observed job failures when using the new GPU kernel for the do-loops containing the onecond* function calls (in Namo's `offload_oneconds` branch). It's not clear at this moment why this happens.